### PR TITLE
Fixed: missing enum option ed25519 for secret key

### DIFF
--- a/tests/src/integration_tests.rs
+++ b/tests/src/integration_tests.rs
@@ -13,7 +13,7 @@ mod tests {
 
     #[test]
     fn should_store_hello_world() {
-        let public_key: PublicKey = SecretKey::ed25519(MY_ACCOUNT).into();
+        let public_key: PublicKey = SecretKey::ed25519_from_bytes(MY_ACCOUNT).unwrap().into();
         let account_addr = AccountHash::from(&public_key);
 
         let mut context = TestContextBuilder::new()


### PR DESCRIPTION
***What does this change do?***

- Fixed: missing enum option ed25519 for secret key

***Why is this change needed?***

- Currently the build and hence integration tests fail with this line